### PR TITLE
Ditched rapidapi built web scraper instead

### DIFF
--- a/app/backend/yfin.py
+++ b/app/backend/yfin.py
@@ -1,39 +1,58 @@
 #----------------------------
 # Import modules
 #----------------------------
+from bs4 import BeautifulSoup as bs
 from flask import jsonify
-from app.util import keys
 import requests as req
 import datetime as dt
 import json
+import lxml
 #----------------------------
+
 
 #----------------------------
 # Get quotes
 #----------------------------
 def get_quotes(symbols):
+
+    # Turn string of symbols to list
     symbols = list(symbols.split(","))
-    url = "https://apidojo-yahoo-finance-v1.p.rapidapi.com/market/v2/get-quotes"
-    query = { "region": "US", "symbols": f"{ ','.join(symbols) }" }
-    headers = {
-        'x-rapidapi-key': keys.YFIN_API_KEY,
-        'x-rapidapi-host': "apidojo-yahoo-finance-v1.p.rapidapi.com"
-    }
-    
-    now = str(dt.datetime.now().strftime("%H:%M:%S"))
-    response = req.request("GET", url, headers=headers, params=query)
 
-    data = json.loads(response.text)
-
+    # Initialize hashtable
     output = {}
-    for idx in enumerate(symbols):
-        symbol = data['quoteResponse']['result'][idx[0]]['symbol']
-        output[symbol] = {
-            'name': data['quoteResponse']['result'][idx[0]]['shortName'],
-            'last': data['quoteResponse']['result'][idx[0]]['regularMarketPrice'],
-            'pchange': f"{round(data['quoteResponse']['result'][idx[0]]['regularMarketChangePercent'],3)}%",
-            'url': f"https://finance.yahoo.com/quote/{symbol}?p={symbol}"
-        }
 
+    # Get data for each symbol
+    for x in symbols:
+
+        # Target url
+        url = f"https://finance.yahoo.com/quote/{x}?p={x}"
+        
+        # Page source
+        response = req.request("GET",url)
+        # Parse with lxml
+        parsed = bs(response.text,"lxml")
+
+        # Defining variables
+        names = parsed.find_all('h1')
+        price = parsed.find('span', {'data-reactid' : '32'}).string
+        change = parsed.find('span', {'data-reactid' : '33'}).string    
+        d1 = change.find('(')+1
+        d2 = change.find(')')
+
+        # Filling hashtable
+        for name in names:
+            delim = name.string.find('(')-1
+            if "Futures," in name.string:
+                name = name.string.replace('Futures,', '')
+                delim = name.find('(')-1
+                output[x] = {'name': name[:delim]}
+            else:
+                output[x] = {'name': name.string[:delim]}
+        output[x]["last"] = price
+        output[x]["pchange"] = change[d1:d2]
+        output[x]["url"] = url
+
+    # Output the hashtable as JSON
     return jsonify(output)
 #----------------------------
+


### PR DESCRIPTION
It's a little slower, but we evade making the user create an account and store keys. This makes it easier for user's to have a seamless build minimizing hoops to jump through. Of course the user can always just change this with a 3rd party api of their choosing with a little python knowledge.